### PR TITLE
Changed 'Model' to 'App'

### DIFF
--- a/getting-started/README.md
+++ b/getting-started/README.md
@@ -24,7 +24,8 @@ Add yew to your dependencies \(refer [here](https://docs.rs/yew) for the latest 
 
 {% code title="Cargo.toml" %}
 ```text
-[package]
+
+[package]
 name = "yew-app"
 version = "0.1.0"
 authors = ["Yew App Developer <name@example.com>"]
@@ -54,7 +55,7 @@ impl Component for App {
     type Properties = ();
 
     fn create(_: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Model { clicked: false }
+        App { clicked: false }
     }
 
     fn update(&mut self, msg: Self::Message) -> ShouldRender {


### PR DESCRIPTION
Following the getting started code without no changes yielded this:
<img width="546" alt="Screen Shot 2019-11-28 at 2 35 11 PM" src="https://user-images.githubusercontent.com/39843321/69833985-4c671700-11ec-11ea-9a3c-2bc1653d3191.png">

This is most possibly a typo caused by renaming the App`struct` (from Model to App) and forgetting to update all its' instances. It is a very minor change but it could be confusing to newcomers so I figured I'd help out.