### PR TITLE
Update links for `todomvc` and `multi_thread`

### DIFF
--- a/src/getting-started/examples.md
+++ b/src/getting-started/examples.md
@@ -2,9 +2,10 @@
 
 The Yew repository is chock-full of examples \(in various states of maintenance\). We recommend perusing them to get a feel for how to use different framework features. We also welcome pull-requests and issues for when they inevitably get neglected and need some ♥️
 
-* [**Todo App**](https://github.com/yewstack/yew/tree/master/examples/todomvc)
+* [**Todo App (stdweb)**](https://github.com/yewstack/yew/tree/master/examples/std_web/todomvc)
+* [**Todo App (web_sys)**](https://github.com/yewstack/yew/tree/master/examples/web_sys/todomvc)
 * [**Custom Components**](https://github.com/yewstack/yew/tree/master/examples/custom_components)
-* [**Multi-threading \(Agents\)**](https://github.com/yewstack/yew/tree/master/examples/multi_thread)
+* [**Multi-threading \(Agents\) (stdweb)**](https://github.com/yewstack/yew/tree/master/examples/std_web/multi_thread)
+* [**Multi-threading \(Agents\) (web_sys)**](https://github.com/yewstack/yew/tree/master/examples/web_sys/multi_thread)
 * [**Timer Service**](https://github.com/yewstack/yew/tree/master/examples/timer)
 * [**Nested Components**](https://github.com/yewstack/yew/tree/master/examples/nested_list)
-


### PR DESCRIPTION
Recently, `todomvc` and `multi_thread` were forked into a `stdweb` and `web_sys` version. The links as the are are broken, so this change fixes those links.