### PR TITLE
Update the sample doc app to use wasm-pack

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 doc-comment = "0.3.3"
+wasm-bindgen = "0.2"
 wasm-bindgen-test = "0.3.0"
 wee_alloc = "0.4"
 yew = { version = "0.15.0", features = ["wasm_test"] }

--- a/src/getting-started/build-a-sample-app.md
+++ b/src/getting-started/build-a-sample-app.md
@@ -6,7 +6,7 @@ First create a new binary project:
 cargo new --bin yew-app && cd yew-app
 ```
 
-Add `yew` to your dependencies \(refer [here](https://docs.rs/yew) for the latest version\)
+Add `yew` and `wasm-bindgen` to your dependencies \(refer [here](https://docs.rs/yew) for the latest version\)
 
 {% code title="Cargo.toml" %}
 ```text
@@ -16,15 +16,20 @@ version = "0.1.0"
 authors = ["Yew App Developer <name@example.com>"]
 edition = "2018"
 
+[lib]
+crate-type = ["cdylib", "rlib"]
+
 [dependencies]
-yew = { version = "0.15", package = "yew-stdweb" }
+yew = "0.15"
+wasm-bindgen = "0.2"
 ```
 {% endcode %}
 
-Copy the following template into your `src/main.rs` file:
+Copy the following template into your `src/lib.rs` file:
 
-{% code title="src/main.rs" %}
+{% code title="src/lib.rs" %}
 ```rust
+use wasm_bindgen::prelude::*;
 use yew::prelude::*;
 
 struct Model {
@@ -70,8 +75,8 @@ impl Component for Model {
     }
 }
 
-fn main() {
-    yew::initialize();
+#[wasm_bindgen(start)]
+pub fn run_app() {
     App::<Model>::new().mount_to_body();
 }
 ```
@@ -79,13 +84,42 @@ fn main() {
 
 This template sets up your root `Component`, called `Model` which shows a button that updates itself when you click it. Take special note of `App::<Model>::new().mount_to_body()` inside `main()` which starts your app and mounts it to the page's `<body>` tag. If you would like to start your application with any dynamic properties, you can instead use `App::<Model>::new().mount_to_body_with_props(..)`.
 
-## Run your App!
-
-Using [`cargo-web`](https://github.com/koute/cargo-web) is the quickest way to get up and running. If you haven't already, install the tool with `cargo install cargo-web` and then build and start a development server by running:
+Finally, add an `index.html` file under a new `static` folder for your app.
 
 ```bash
-cargo web start
+mkdir static
+``` 
+
+{% code title="index.html" %}
+```html
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <title>Yew Sample App</title>
+        <script type="module">
+			import init from "./wasm.js"
+			init()
+		</script>
+    </head>
+    <body></body>
+</html>
+```
+{% endcode %}
+
+## Run your App!
+
+Using [`wasm-pack`](https://rustwasm.github.io/docs/wasm-pack/) is the preferred way to get up and running. If you haven't already, install the tool with `cargo install wasm-pack` and then build and start a development server by running:
+
+```bash
+wasm-pack build --target web --out-name wasm --out-dir ./static
 ```
 
-`cargo-web` will automatically add the `wasm32-unknown-unknown` target for you, build your app, and finally make it available at [http://\[::1\]:8000](http://[::1]:8000) by default. Consult `cargo web start --help` for other options.
+`wasm-pack` generates a bundle in the `./static` directory with your app's compiled WebAssembly along with a JavaScript wrapper which can be used to start your application.
+
+Then, use your favorite web server to server the files under `./static`. For example:
+
+```bash
+python -m http.server 8000 --directory static
+```
 

--- a/src/getting-started/build-a-sample-app.md
+++ b/src/getting-started/build-a-sample-app.md
@@ -3,7 +3,7 @@
 First create a new binary project:
 
 ```bash
-cargo new --bin yew-app && cd yew-app
+cargo new yew-app && cd yew-app
 ```
 
 Add `yew` and `wasm-bindgen` to your dependencies \(refer [here](https://docs.rs/yew) for the latest version\)
@@ -84,7 +84,7 @@ pub fn run_app() {
 
 This template sets up your root `Component`, called `Model` which shows a button that updates itself when you click it. Take special note of `App::<Model>::new().mount_to_body()` inside `main()` which starts your app and mounts it to the page's `<body>` tag. If you would like to start your application with any dynamic properties, you can instead use `App::<Model>::new().mount_to_body_with_props(..)`.
 
-Finally, add an `index.html` file under a new `static` folder for your app.
+Finally, add an `index.html` file into a new folder named `static` in your app.
 
 ```bash
 mkdir static
@@ -109,13 +109,14 @@ mkdir static
 
 ## Run your App!
 
-Using [`wasm-pack`](https://rustwasm.github.io/docs/wasm-pack/) is the preferred way to get up and running. If you haven't already, install the tool with `cargo install wasm-pack` and then build and start a development server by running:
+Using [`wasm-pack`](https://rustwasm.github.io/docs/wasm-pack/) is the preferred way to get up and running.
+If you haven't already, install `wasm-pack` with `cargo install wasm-pack` and then build and start a development server by running:
 
 ```bash
 wasm-pack build --target web --out-name wasm --out-dir ./static
 ```
 
-`wasm-pack` generates a bundle in the `./static` directory with your app's compiled WebAssembly along with a JavaScript wrapper which can be used to start your application.
+`wasm-pack` generates a bundle in the `./static` directory with your app's compiled WebAssembly along with a JavaScript wrapper which will load your application's WebAssembly binary and run it.
 
 Then, use your favorite web server to server the files under `./static`. For example:
 

--- a/src/getting-started/build-a-sample-app.md
+++ b/src/getting-started/build-a-sample-app.md
@@ -121,6 +121,7 @@ wasm-pack build --target web --out-name wasm --out-dir ./static
 Then, use your favorite web server to server the files under `./static`. For example:
 
 ```bash
-python -m http.server 8000 --directory static
+cargo +nightly install miniserver
+miniserve ./static --index index.html
 ```
 


### PR DESCRIPTION
According to the rest of the documentation, wasm-pack and web-sys are
the recommended tool to use. However, the sample app documents the usage
of cargo-web and stdweb.

The command lines are taken from the example folder of yew.