### PR TITLE
Expanded getting started/project setup/wasm-pack docs

### DIFF
--- a/src/getting-started/project-setup/using-wasm-pack.md
+++ b/src/getting-started/project-setup/using-wasm-pack.md
@@ -6,10 +6,58 @@ This tool was created by the Rust / Wasm Working Group and is the most actively 
 Note that the crate-type in your `Cargo.toml` will need to be `cdylib` when using `wasm-pack`
 {% endhint %}
 
-### Install
+### Install wasm-pack
 
 ```bash
 cargo install wasm-pack
+```
+
+### Set up your project
+
+{% hint style="info" %}
+If you start from the [yew-wasm-pack-minimal](https://github.com/yewstack/yew-wasm-pack-minimal) template, these setup steps are already taken care of.
+{% endhint %}
+
+* Add a minimal `index.html` file to your project root:
+```html
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <title>Yew</title>
+    </head>
+    <body>
+        <script src="pkg/bundle.js"></script>
+    </body>
+</html>
+```
+
+* Add a `main.js` file with these contents to your project root:
+```javascript
+import init, { run_app } from './pkg/myapp.js';
+async function main() {
+   await init('/pkg/myapp_bg.wasm');
+   run_app();
+}
+main()
+```
+
+* Add `wasm-bindgen` as a dependency in `Cargo.toml`:
+```toml
+[dependencies]
+wasm-bindgen = "^0.2"
+```
+
+* Add a `run_app` function to `lib.rs`:
+```rust
+use wasm_bindgen::prelude;
+
+#[wasm_bindgen]
+pub fn run_app() -> Result<(), JsValue> {
+    yew::start_app::<Model>();
+
+    Ok(())
+}
 ```
 
 ### Build
@@ -22,11 +70,19 @@ wasm-pack build --target web
 
 ### Bundle
 
-For more information on Rollup visit this [guide](https://rollupjs.org/guide/en/#quick-start)
+You need the `wasm` plugin for `rollup`:
 
 ```bash
-rollup ./main.js --format iife --file ./pkg/bundle.js
+npm install @rollup/plugin-wasm --save-dev
 ```
+
+Now you can bundle your application:
+
+```bash
+rollup ./main.js --format iife --plugin wasm --file ./pkg/bundle.js
+```
+
+For more information on Rollup visit this [guide](https://rollupjs.org/guide/en/#quick-start).
 
 ### Serve
 

--- a/src/getting-started/project-setup/using-wasm-pack.md
+++ b/src/getting-started/project-setup/using-wasm-pack.md
@@ -15,7 +15,7 @@ cargo install wasm-pack
 ### Set up your project
 
 {% hint style="info" %}
-If you start from the [yew-wasm-pack-minimal](https://github.com/yewstack/yew-wasm-pack-minimal) template, these setup steps are already taken care of.
+If you use the [yew-wasm-pack-minimal](https://github.com/yewstack/yew-wasm-pack-minimal) template, these setup steps are already taken care of.
 {% endhint %}
 
 * Add a minimal `index.html` file to your project root:


### PR DESCRIPTION
This explains in much more detail what you need to do to get a project running with `wasm-pack`.

It references https://github.com/yewstack/yew-wasm-pack-minimal as part of an info box, but the instructions here are actually pretty redundant with the instructions there, so maybe it would be better to just send people to the template and tell them to read the instructions there.

Fixes #60. I think.