### PR TITLE
Add a note telling how to bypass the recursion limit of the html! macro.

### DIFF
--- a/src/concepts/html/README.md
+++ b/src/concepts/html/README.md
@@ -11,7 +11,9 @@ The `html!` macro allows you to write HTML and SVG code declaratively. It is sim
 1. The `html!` macro only accepts one root html node \(you can counteract this by [using fragments or iterators](lists.md)\)
 2. An empty `html! {}` invocation is valid and will not render anything
 3. Literals must always be quoted and wrapped in braces: `html! { "Hello, World" }`
-4. The `html!` macro can reach easily the default recursion limit of the compiler. It is advised to bump its value if you encouter compilation errors. Use an attribute like `#![recursion_limit="100000"]` to bypass the problem. See the [official documentation](https://doc.rust-lang.org/reference/attributes/limits.html#the-recursion_limit-attribute) and [this Stack Overflow question](https://stackoverflow.com/questions/27454761/what-is-a-crate-attribute-and-where-do-i-add-it) for details.
+{% hint style="info" %}
+The `html!` macro can reach easily the default recursion limit of the compiler. It is advised to bump its value if you encouter compilation errors. Use an attribute like `#![recursion_limit="100000"]` to bypass the problem. See the [official documentation](https://doc.rust-lang.org/reference/attributes/limits.html#the-recursion_limit-attribute) and [this Stack Overflow question](https://stackoverflow.com/questions/27454761/what-is-a-crate-attribute-and-where-do-i-add-it) for details.
+{% endhint %}
 
 {% page-ref page="lists.md" %}
 
@@ -20,4 +22,3 @@ The `html!` macro allows you to write HTML and SVG code declaratively. It is sim
 {% page-ref page="literals-and-expressions.md" %}
 
 {% page-ref page="components.md" %}
-

--- a/src/concepts/html/README.md
+++ b/src/concepts/html/README.md
@@ -11,6 +11,7 @@ The `html!` macro allows you to write HTML and SVG code declaratively. It is sim
 1. The `html!` macro only accepts one root html node \(you can counteract this by [using fragments or iterators](lists.md)\)
 2. An empty `html! {}` invocation is valid and will not render anything
 3. Literals must always be quoted and wrapped in braces: `html! { "Hello, World" }`
+4. The `html!` macro can reach easily the default recursion limit of the compiler. It is advised to bump its value if you encouter compilation errors. Use an attribute like `#![recursion_limit="100000"]` to bypass the problem. See the [official documentation](https://doc.rust-lang.org/reference/attributes/limits.html#the-recursion_limit-attribute) and [this Stack Overflow question](https://stackoverflow.com/questions/27454761/what-is-a-crate-attribute-and-where-do-i-add-it) for details.
 
 {% page-ref page="lists.md" %}
 

--- a/src/concepts/html/README.md
+++ b/src/concepts/html/README.md
@@ -12,7 +12,7 @@ The `html!` macro allows you to write HTML and SVG code declaratively. It is sim
 2. An empty `html! {}` invocation is valid and will not render anything
 3. Literals must always be quoted and wrapped in braces: `html! { "Hello, World" }`
 {% hint style="info" %}
-The `html!` macro can reach easily the default recursion limit of the compiler. It is advised to bump its value if you encouter compilation errors. Use an attribute like `#![recursion_limit="100000"]` to bypass the problem. See the [official documentation](https://doc.rust-lang.org/reference/attributes/limits.html#the-recursion_limit-attribute) and [this Stack Overflow question](https://stackoverflow.com/questions/27454761/what-is-a-crate-attribute-and-where-do-i-add-it) for details.
+The `html!` macro can reach easily the default recursion limit of the compiler. It is advised to bump its value if you encouter compilation errors. Use an attribute like `#![recursion_limit="1024"]` to bypass the problem. See the [official documentation](https://doc.rust-lang.org/reference/attributes/limits.html#the-recursion_limit-attribute) and [this Stack Overflow question](https://stackoverflow.com/questions/27454761/what-is-a-crate-attribute-and-where-do-i-add-it) for details.
 {% endhint %}
 
 {% page-ref page="lists.md" %}


### PR DESCRIPTION
As discussed in [issue #1260](https://github.com/yewstack/yew/issues/1260)