### PR TITLE
Point to master branch for examples

### DIFF
--- a/src/getting-started/examples.md
+++ b/src/getting-started/examples.md
@@ -1,10 +1,10 @@
 # Learn through examples
 
-The Yew repository is chock-full of [examples](https://github.com/yewstack/yew/tree/v0.15.0/examples) \(in various states of maintenance\). We recommend perusing them to get a feel for how to use different framework features. We also welcome pull-requests and issues for when they inevitably get neglected and need some ♥️
+The Yew repository is chock-full of [examples](https://github.com/yewstack/yew/tree/master/examples) \(in various states of maintenance\). We recommend perusing them to get a feel for how to use different framework features. We also welcome pull-requests and issues for when they inevitably get neglected and need some ♥️
 
-* [**Todo App** ](https://github.com/yewstack/yew/tree/v0.15.0/examples/todomvc)
-* [**Custom Components**](https://github.com/yewstack/yew/tree/v0.15.0/examples/custom_components)
-* [**Multi-threading \(Agents\)**](https://github.com/yewstack/yew/tree/v0.15.0/examples/multi_thread)
-* [**Timer Service**](https://github.com/yewstack/yew/tree/v0.15.0/examples/timer)
-* [**Nested Components**](https://github.com/yewstack/yew/tree/v0.15.0/examples/nested_list)
+* [**Todo App** ](https://github.com/yewstack/yew/tree/master/examples/todomvc)
+* [**Custom Components**](https://github.com/yewstack/yew/tree/master/examples/custom_components)
+* [**Multi-threading \(Agents\)**](https://github.com/yewstack/yew/tree/master/examples/multi_thread)
+* [**Timer Service**](https://github.com/yewstack/yew/tree/master/examples/timer)
+* [**Nested Components**](https://github.com/yewstack/yew/tree/master/examples/nested_list)
 

--- a/src/getting-started/examples.md
+++ b/src/getting-started/examples.md
@@ -2,9 +2,8 @@
 
 The Yew repository is chock-full of [examples](https://github.com/yewstack/yew/tree/master/examples) \(in various states of maintenance\). We recommend perusing them to get a feel for how to use different framework features. We also welcome pull-requests and issues for when they inevitably get neglected and need some ♥️
 
-* [**Todo App** ](https://github.com/yewstack/yew/tree/master/examples/todomvc)
+* [**Todo App** ](https://github.com/yewstack/yew/tree/v0.16.0/examples/todomvc)
 * [**Custom Components**](https://github.com/yewstack/yew/tree/master/examples/custom_components)
 * [**Multi-threading \(Agents\)**](https://github.com/yewstack/yew/tree/master/examples/multi_thread)
 * [**Timer Service**](https://github.com/yewstack/yew/tree/master/examples/timer)
 * [**Nested Components**](https://github.com/yewstack/yew/tree/master/examples/nested_list)
-

--- a/src/getting-started/examples.md
+++ b/src/getting-started/examples.md
@@ -1,6 +1,6 @@
 # Learn through examples
 
-The Yew repository is chock-full of [examples](https://github.com/yewstack/yew/tree/master/examples) \(in various states of maintenance\). We recommend perusing them to get a feel for how to use different framework features. We also welcome pull-requests and issues for when they inevitably get neglected and need some ♥️
+The Yew repository is chock-full of [examples](https://github.com/yewstack/yew/tree/v0.16.0/examples) \(in various states of maintenance\). We recommend perusing them to get a feel for how to use different framework features. We also welcome pull-requests and issues for when they inevitably get neglected and need some ♥️
 
 * [**Todo App** ](https://github.com/yewstack/yew/tree/v0.16.0/examples/todomvc)
 * [**Custom Components**](https://github.com/yewstack/yew/tree/v0.16.0/examples/custom_components)

--- a/src/getting-started/examples.md
+++ b/src/getting-started/examples.md
@@ -3,7 +3,7 @@
 The Yew repository is chock-full of [examples](https://github.com/yewstack/yew/tree/master/examples) \(in various states of maintenance\). We recommend perusing them to get a feel for how to use different framework features. We also welcome pull-requests and issues for when they inevitably get neglected and need some ♥️
 
 * [**Todo App** ](https://github.com/yewstack/yew/tree/v0.16.0/examples/todomvc)
-* [**Custom Components**](https://github.com/yewstack/yew/tree/master/examples/custom_components)
-* [**Multi-threading \(Agents\)**](https://github.com/yewstack/yew/tree/master/examples/multi_thread)
-* [**Timer Service**](https://github.com/yewstack/yew/tree/master/examples/timer)
-* [**Nested Components**](https://github.com/yewstack/yew/tree/master/examples/nested_list)
+* [**Custom Components**](https://github.com/yewstack/yew/tree/v0.16.0/examples/custom_components)
+* [**Multi-threading \(Agents\)**](https://github.com/yewstack/yew/tree/v0.16.0/examples/multi_thread)
+* [**Timer Service**](https://github.com/yewstack/yew/tree/v0.16.0/examples/timer)
+* [**Nested Components**](https://github.com/yewstack/yew/tree/v0.16.0/examples/nested_list)


### PR DESCRIPTION
While I'm assuming there was initially a reason for pinning the examples to a specific git tag, is this still the case?