### PR TITLE
bumping up the yew version in Cargo.toml (#107)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,4 @@ doc-comment = "0.3.3"
 wasm-bindgen = "0.2"
 wasm-bindgen-test = "0.3.0"
 wee_alloc = "0.4"
-yew = { version = "0.15.0", features = ["wasm_test"] }
+yew = { version = "0.16.0", features = ["wasm_test"] }

--- a/src/getting-started/choose-web-library.md
+++ b/src/getting-started/choose-web-library.md
@@ -12,7 +12,7 @@ You'll need to choose one or the other when adding `yew` to your cargo dependenc
 yew = "0.16"
 
 # Choose `stdweb`
-yew = { version = "0.15", package = "yew-stdweb" }
+yew = { version = "0.16", package = "yew-stdweb" }
 ```
 {% endcode %}
 

--- a/src/getting-started/choose-web-library.md
+++ b/src/getting-started/choose-web-library.md
@@ -9,7 +9,7 @@ You'll need to choose one or the other when adding `yew` to your cargo dependenc
 {% code title="Cargo.toml" %}
 ```rust
 # Choose `web-sys`
-yew = "0.15"
+yew = "0.16"
 
 # Choose `stdweb`
 yew = { version = "0.15", package = "yew-stdweb" }

--- a/src/getting-started/starter-templates.md
+++ b/src/getting-started/starter-templates.md
@@ -27,7 +27,7 @@ crate-type = ["cdylib"]
 # for web_sys
 yew = "0.16"
 # or for stdweb
-# yew = { version = "0.15", package = "yew-stdweb" }
+# yew = { version = "0.16", package = "yew-stdweb" }
 wasm-bindgen = "0.2"
 ```
 {% endcode %}

--- a/src/more/debugging.md
+++ b/src/more/debugging.md
@@ -24,7 +24,7 @@ fn main() {
 log::info!("Update: {:?}", msg);
 ```
 
-### [`ConsoleService`](https://docs.rs/yew/0.16.0/yew/services/console/struct.ConsoleService.html)
+### [`ConsoleService`](https://docs.rs/yew/latest/yew/services/console/struct.ConsoleService.html)
 
 This service is included within yew and is available when the `"services"` feature is enabled:
 

--- a/src/more/debugging.md
+++ b/src/more/debugging.md
@@ -24,7 +24,7 @@ fn main() {
 log::info!("Update: {:?}", msg);
 ```
 
-### **\`\`**[**`ConsoleService`**](https://docs.rs/yew/0.15.0/yew/services/console/struct.ConsoleService.html)**\`\`**
+### [`ConsoleService`](https://docs.rs/yew/0.16.0/yew/services/console/struct.ConsoleService.html)
 
 This service is included within yew and is available when the `"services"` feature is enabled:
 
@@ -51,4 +51,3 @@ change. If this is no longer true or if progress is made, please suggest a chang
 \[2019\] [Rust Wasm roadmap](https://rustwasm.github.io/rfcs/007-2019-roadmap.html#debugging)
 
 > Debugging is tricky because much of the story is out of this working group's hands, and depends on both the WebAssembly standardization bodies and the folks implementing browser developer tools instead.
-


### PR DESCRIPTION
396adab6a840d2bd8947ab8170a7392c13aa9734
Should I bumping up the yew version of stdwebs too?

https://github.com/yewstack/docs/blob/b888b894cdf81d2a106bd0b7ad52bb7799a6e05b/src/getting-started/starter-templates.md#L29-L30

https://github.com/yewstack/docs/blob/b888b894cdf81d2a106bd0b7ad52bb7799a6e05b/src/getting-started/choose-web-library.md#L14-L15